### PR TITLE
Force battery temperature to 0 on comma two (#168)

### DIFF
--- a/selfdrive/thermald/thermald.py
+++ b/selfdrive/thermald/thermald.py
@@ -253,6 +253,7 @@ def thermald_thread():
     if is_uno:
       msg.thermal.batteryPercent = 100
       msg.thermal.batteryStatus = "Charging"
+      msg.thermal.bat = 0
 
     current_filter.update(msg.thermal.batteryCurrent / 1e6)
 


### PR DESCRIPTION
Fix for false temperature warnings on c2

https://github.com/commaai/openpilot/commit/e909fddac06acb1a602e3f25578c61a9e2b3ec11